### PR TITLE
Remove Yasson with Resteasy version 3.6.2 from runtime deps

### DIFF
--- a/resteasy-spring-boot-starter-test/pom.xml
+++ b/resteasy-spring-boot-starter-test/pom.xml
@@ -100,12 +100,6 @@
             <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <version>1.0.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/resteasy-spring-boot-starter/pom.xml
+++ b/resteasy-spring-boot-starter/pom.xml
@@ -59,7 +59,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springboot.version>2.0.4.RELEASE</springboot.version>
-        <resteasy.version>3.6.1.Final</resteasy.version>
+        <resteasy.version>3.6.2.Final</resteasy.version>
         <coverage.line>80</coverage.line>
         <coverage.branch>80</coverage.branch>
         <modular.jdk.args/>
@@ -122,12 +122,6 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <version>1.0.1</version>
-            <scope>runtime</scope>
         </dependency>
     
         <!-- Test dependencies -->

--- a/sample-app/pom.xml
+++ b/sample-app/pom.xml
@@ -15,7 +15,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <resteasy.version>3.6.1.Final</resteasy.version>
+        <resteasy.version>3.6.2.Final</resteasy.version>
         <springboot.version>2.0.4.RELEASE</springboot.version>
     </properties>
     
@@ -56,11 +56,6 @@
             <artifactId>resteasy-spring-boot-starter</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>


### PR DESCRIPTION
Using something like Jackson, finally with 3.6.2 we a re able to remove unnecessary hanging Yasson.