### PR TITLE
Fix property name needed to enable Resteasy properties

### DIFF
--- a/mds/USAGE.md
+++ b/mds/USAGE.md
@@ -63,12 +63,12 @@ __Important notes__
 1. When no JAX-RS Application is configured, the property `resteasy.jaxrs.defaultPath` can be used to define the base path. It defaults to `/` if not set
 
 #### RESTEasy configuration
-RESTEasy offers a few configuration switches, [as seen here](http://docs.jboss.org/resteasy/docs/3.1.0.Final/userguide/html_single/index.html#configuration_switches), and they are set as Servlet context init parameters. In Spring Boot, Servlet context init parameters are defined via Spring Boot `application.properties` file, using the property prefix `server.context-parameters.*` (search for it in [Spring Boot reference guide](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/)).</br>
+RESTEasy offers a few configuration switches, [as seen here](http://docs.jboss.org/resteasy/docs/3.1.0.Final/userguide/html_single/index.html#configuration_switches), and they are set as Servlet context init parameters. In Spring Boot, Servlet context init parameters are defined via Spring Boot `application.properties` file, using the property prefix `server.servlet.context-parameters.*` (search for it in [Spring Boot reference guide](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/)).</br>
 
 As an example, to set RESTEasy property `resteasy.role.based.security` to `true`, just add the property bellow to Spring Boot `application.properties` file.
 
 ```
-server.context-parameters.resteasy.role.based.security=true
+server.servlet.context-parameters.resteasy.role.based.security=true
 ```
 
 It is important to mention that the following RESTEasy configuration options are NOT applicable to an application using RESTEasy Spring Boot starter.


### PR DESCRIPTION
A Spring Boot context-parameter actually uses the prefix "server.servlet.context-parameters"

---

I ran into this issue trying to set `resteasy.async.job.service.enabled`.  Using the `server.servlet.context-parameters` prefix, the async service works.  With `servlet.context-parameters`, it doesn't.  Oddly, the Spring Boot documents are nearly silent on how to set context parameters.  I found a [Stack Overflow](https://stackoverflow.com/questions/26639475/how-to-set-context-param-in-spring-boot#26648258) question on the issue but it suggests using a Bean.  Perhaps that might be the best thing to have in the documentation long-term?