### PR TITLE
Support resteasy.servlet.mapping.prefix

### DIFF
--- a/mds/USAGE.md
+++ b/mds/USAGE.md
@@ -59,11 +59,12 @@ __Important notes__
 
 - If no JAX-RS application classes are found, a default one will be automatically created mapping to `/*` (_according to section 2.3.2 in the JAX-RS 2.0 specification_). Notice that, in this case, if you have any other Servlet in your application, their URL matching might conflict. For example, if you have Spring Boot actuator and its mapped to `/`, its endpoints might not be reachable.
 - It is recommended to always have at least one JAX-RS application class.
-- A JAX-RS application class with no `javax.ws.rs.ApplicationPath` annotation will not be registered.
+- A JAX-RS application class with no `javax.ws.rs.ApplicationPath` annotation will not be registered, unless `resteasy.servlet.mapping.prefix` is specified.
 - Avoid setting the JAX-RS application base URI to simply `/` to prevent URI conflicts, as explained in item 1.
 - Property `resteasy.jaxrs.app` has been deprecated and replaced by `resteasy.jaxrs.app.classes` since version *2.2.0-RELEASE* (see [issue 35](https://github.com/paypal/resteasy-spring-boot/issues/35)). Property `resteasy.jaxrs.app` is going to be finally removed in version *3.0.0-RELEASE*.
 - Starting on version 3.0.0, the behavior of the `scanning` JAX-RS Application subclass registration method will change, being more restrictive. Instead of scanning the whole classpath, it will scan only packages registered to be scanned by Spring framework (regardless of the JAX-RS Application subclass being a Spring bean or not). The reason is to improve application startup performance. Having said that, it is recommended that every application use any method, other than `scanning`. Or, if using `scanning`, make sure your JAX-RS Application subclass is under a package to be scanned by Spring framework. If not, starting on version 3.0.0,it won't be found.
 - When no JAX-RS Application is configured, the property `resteasy.jaxrs.defaultPath` can be used to define the base path. It defaults to `/` if not set
+- `resteasy.servlet.mapping.prefix` will override `javax.ws.rs.ApplicationPath` if both are specified.
 
 #### RESTEasy configuration
 
@@ -81,5 +82,4 @@ All other RESTEasy configuration options are supported normally.
 | Configuration option | Why it is not applicable |
 |---|---|
 |`javax.ws.rs.Application`|JAX-RS application classes are registered as explained in section _"JAX-RS application registration methods"_ above|
-|`resteasy.servlet.mapping.prefix`|The url-pattern for the Resteasy servlet-mapping is always based on the `ApplicationPath` annotation in the JAX-RS application class|
 |`resteasy.scan`<br/>`resteasy.scan.providers`<br/>`resteasy.scan.resources`<br/>`resteasy.providers`<br/>`resteasy.use.builtin.providers`<br/>`resteasy.resources`<br/>`resteasy.jndi.resources`|All JAX-RS resources and providers are always supposed to be Spring beans, and they are automatically discovered|

--- a/resteasy-spring-boot-starter/src/test/java/org/jboss/resteasy/springboot/JaxrsAppRegistrationTest.java
+++ b/resteasy-spring-boot-starter/src/test/java/org/jboss/resteasy/springboot/JaxrsAppRegistrationTest.java
@@ -217,9 +217,9 @@ public class JaxrsAppRegistrationTest extends PowerMockTestCase {
         resteasyEmbeddedServletInitializer.postProcessBeanFactory(beanFactory);
 
         if(getAppsProperty) {
-            verify(beanFactory, VerificationModeFactory.atLeast(2)).getBean(ConfigurableEnvironment.class);
+            verify(beanFactory, VerificationModeFactory.atLeast(3)).getBean(ConfigurableEnvironment.class);
         } else {
-            verify(beanFactory, VerificationModeFactory.times(1)).getBean(ConfigurableEnvironment.class);
+            verify(beanFactory, VerificationModeFactory.times(2)).getBean(ConfigurableEnvironment.class);
         }
         
         verify(beanFactory, VerificationModeFactory.times(findSpringBeans ? 1 : 0)).getBeansOfType(Application.class, true, false);


### PR DESCRIPTION
With this change, a JAX-RS application class without `javax.ws.rs.ApplicationPath`
can be registered, as long as `resteasy.servlet.mapping.prefix` is
specified.

If both are specified, then `resteasy.servlet.mapping.prefix` wins.