### PR TITLE
fix: test scope for junit-jupiter-api

### DIFF
--- a/resteasy-spring-boot-starter/pom.xml
+++ b/resteasy-spring-boot-starter/pom.xml
@@ -392,6 +392,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.5.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
`org.junit.jupiter:junit-jupiter-api` is currently set to `compile` scope (the default) and would be included in the packaged artifact of the application using the starter. This sets the scope to `test`.