### PR TITLE
Upgrade RESTeasy to 3.12.1

### DIFF
--- a/resteasy-spring-boot-starter/pom.xml
+++ b/resteasy-spring-boot-starter/pom.xml
@@ -59,7 +59,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springboot.version>2.2.5.RELEASE</springboot.version>
-        <resteasy.version>3.11.2.Final</resteasy.version>
+        <resteasy.version>3.12.1.Final</resteasy.version>
         <resteasy.jackson.version>2.10.3</resteasy.jackson.version>
         <jboss-logging.ver>3.4.0.Final</jboss-logging.ver>
         <modular.jdk.args/>

--- a/sample-app-no-jaxrs-application/pom.xml
+++ b/sample-app-no-jaxrs-application/pom.xml
@@ -16,7 +16,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <resteasy.version>3.11.2.Final</resteasy.version>
+        <resteasy.version>3.12.1.Final</resteasy.version>
         <springboot.version>2.2.5.RELEASE</springboot.version>
     </properties>
 

--- a/sample-app/pom.xml
+++ b/sample-app/pom.xml
@@ -15,7 +15,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <resteasy.version>3.11.2.Final</resteasy.version>
+        <resteasy.version>3.12.1.Final</resteasy.version>
         <springboot.version>2.2.5.RELEASE</springboot.version>
     </properties>
     


### PR DESCRIPTION
Latest resteasy version fixes the vulnerability specified in
https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-1695